### PR TITLE
disable xattr support in simple vfs config

### DIFF
--- a/arch/x86/syscalls/Makefile
+++ b/arch/x86/syscalls/Makefile
@@ -11,6 +11,7 @@ syscall64 := $(srctree)/$(src)/syscall_64.tbl
 syshdr := $(srctree)/$(src)/syscallhdr.sh
 systbl := $(srctree)/$(src)/syscalltbl.sh
 
+ifndef CONFIG_XATTR_NO_SUPPORT
 quiet_cmd_syshdr = SYSHDR  $@
       cmd_syshdr = $(CONFIG_SHELL) '$(syshdr)' '$<' '$@' \
 		   '$(syshdr_abi_$(basetarget))' \
@@ -18,6 +19,15 @@ quiet_cmd_syshdr = SYSHDR  $@
 		   '$(syshdr_offset_$(basetarget))'
 quiet_cmd_systbl = SYSTBL  $@
       cmd_systbl = $(CONFIG_SHELL) '$(systbl)' $< $@
+else
+quiet_cmd_syshdr = SYSHDR  $@
+      cmd_syshdr = $(CONFIG_SHELL) '$(syshdr)' '$<' '$@' \
+		   '$(syshdr_abi_$(basetarget))' \
+		   '$(syshdr_pfx_$(basetarget))' \
+		   '$(syshdr_offset_$(basetarget))' 'no_xattr_syscall'
+quiet_cmd_systbl = SYSTBL  $@
+      cmd_systbl = $(CONFIG_SHELL) '$(systbl)' $< $@ 'no_xattr_syscall'
+endif
 
 syshdr_abi_unistd_32 := i386
 $(uapi)/unistd_32.h: $(syscall32) $(syshdr)

--- a/arch/x86/syscalls/syscallhdr.sh
+++ b/arch/x86/syscalls/syscallhdr.sh
@@ -6,6 +6,9 @@ my_abis=`echo "($3)" | tr ',' '|'`
 prefix="$4"
 offset="$5"
 
+xattr_flag="$6"
+syscall_file="$(basename $1 .tbl)"
+
 fileguard=_ASM_X86_`basename "$out" | sed \
     -e 'y/abcdefghijklmnopqrstuvwxyz/ABCDEFGHIJKLMNOPQRSTUVWXYZ/' \
     -e 's/[^A-Z0-9_]/_/g' -e 's/__/_/g'`
@@ -14,13 +17,47 @@ grep -E "^[0-9A-Fa-fXx]+[[:space:]]+${my_abis}" "$in" | sort -n | (
     echo "#define ${fileguard} 1"
     echo ""
 
-    while read nr abi name entry ; do
-	if [ -z "$offset" ]; then
-	    echo "#define __NR_${prefix}${name} $nr"
-	else
-	    echo "#define __NR_${prefix}${name} ($offset + $nr)"
-        fi
-    done
+    if ([ "$xattr_flag" = "no_xattr_syscall" ] && [ "$syscall_file" = "syscall_32" ]); then
+
+	while read nr abi name entry ; do
+	    case $nr in
+		22[6-9]) continue ;;
+		23[0-7]) continue ;;
+		*) ;;
+	    esac
+	    if [ -z "$offset" ]; then
+		echo "#define __NR_${prefix}${name} $nr"
+	    else
+		echo "#define __NR_${prefix}${name} ($offset + $nr)"
+	    fi
+	done
+
+    elif ([ "$xattr_flag" = "no_xattr_syscall" ] && [ "$syscall_file" = "syscall_64" ]); then
+
+	while read nr abi name entry ; do
+	    case $nr in
+		18[8-9]) continue ;;
+		19[0-9]) continue ;;
+		*) ;;
+	    esac
+	    if [ -z "$offset" ]; then
+		echo "#define __NR_${prefix}${name} $nr"
+	    else
+		echo "#define __NR_${prefix}${name} ($offset + $nr)"
+	    fi
+	done
+
+    else
+
+	while read nr abi name entry ; do
+	    if [ -z "$offset" ]; then
+		echo "#define __NR_${prefix}${name} $nr"
+	    else
+		echo "#define __NR_${prefix}${name} ($offset + $nr)"
+	    fi
+	done
+
+    fi
 
     echo ""
     echo "#endif /* ${fileguard} */"

--- a/arch/x86/syscalls/syscalltbl.sh
+++ b/arch/x86/syscalls/syscalltbl.sh
@@ -3,13 +3,52 @@
 in="$1"
 out="$2"
 
+xattr_flag="$3"
+syscall_file="$(basename $1 .tbl)"
+
 grep '^[0-9]' "$in" | sort -n | (
-    while read nr abi name entry compat; do
-	abi=`echo "$abi" | tr '[a-z]' '[A-Z]'`
-	if [ -n "$compat" ]; then
-	    echo "__SYSCALL_${abi}($nr, $entry, $compat)"
-	elif [ -n "$entry" ]; then
-	    echo "__SYSCALL_${abi}($nr, $entry, $entry)"
-	fi
-    done
+    if ([ "$xattr_flag" = "no_xattr_syscall" ] && [ "$syscall_file" = "syscall_32" ]); then
+
+	    while read nr abi name entry compat; do
+		case $nr in
+		    22[6-9]) continue ;;
+		    23[0-7]) continue ;;
+		    *) ;;
+		esac
+		abi=`echo "$abi" | tr '[a-z]' '[A-Z]'`
+		if [ -n "$compat" ]; then
+		    echo "__SYSCALL_${abi}($nr, $entry, $compat)"
+		elif [ -n "$entry" ]; then
+		    echo "__SYSCALL_${abi}($nr, $entry, $entry)"
+		fi
+	    done
+
+    elif ([ "$xattr_flag" = "no_xattr_syscall" ] && [ "$syscall_file" = "syscall_64" ]); then
+
+	    while read nr abi name entry compat; do
+		case $nr in
+		    18[8-9]) continue ;;
+		    19[0-9]) continue ;;
+		    *) ;;
+		esac
+		abi=`echo "$abi" | tr '[a-z]' '[A-Z]'`
+		if [ -n "$compat" ]; then
+		    echo "__SYSCALL_${abi}($nr, $entry, $compat)"
+		elif [ -n "$entry" ]; then
+		    echo "__SYSCALL_${abi}($nr, $entry, $entry)"
+		fi
+	    done
+
+    else
+
+	    while read nr abi name entry compat; do
+		abi=`echo "$abi" | tr '[a-z]' '[A-Z]'`
+		if [ -n "$compat" ]; then
+		    echo "__SYSCALL_${abi}($nr, $entry, $compat)"
+		elif [ -n "$entry" ]; then
+		    echo "__SYSCALL_${abi}($nr, $entry, $entry)"
+		fi
+	    done
+
+    fi
 ) > "$out"

--- a/fs/Kconfig
+++ b/fs/Kconfig
@@ -272,4 +272,32 @@ endif # NETWORK_FILESYSTEMS
 source "fs/nls/Kconfig"
 source "fs/dlm/Kconfig"
 
+#
+# Simple VFS Configuration
+#
+# It's used to decrease the size of kernel.
+#
+menu "Simple VFS configs"
+
+config XATTR_NO_SUPPORT
+	bool "Disable XATTR (Extended Attributes) support"
+	default n
+	depends on KERNFS =n && EXT2_FS_XATTR=n && EXT3_FS_XATTR=n && TMPFS_XATTR=n && \
+AUFS_XATTR=n && CIFS_XATTR=n && F2FS_FS_XATTR=n && JFFS2_FS_XATTR=n && \
+REISERFS_FS_XATTR=n && SQUASHFS_XATTR=n && YAFFS_XATTR=n
+
+	help
+	  This option disables the support for XATTR (Extended Attributes).
+
+	  Say Y here to decrease the size of kernel,
+	  and then some syscall definitions will not be compiled.
+
+	  Users considering disabling this option should consider the specific
+	  filesystems. Some filesystems (e.g. EXT2/EXT3/TMPFS) need the support
+	  for XATTR.
+
+	  If unsure, say N here.
+
+endmenu
+
 endmenu

--- a/fs/Kconfig
+++ b/fs/Kconfig
@@ -282,7 +282,7 @@ menu "Simple VFS configs"
 config XATTR_NO_SUPPORT
 	bool "Disable XATTR (Extended Attributes) support"
 	default n
-	depends on KERNFS =n && EXT2_FS_XATTR=n && EXT3_FS_XATTR=n && TMPFS_XATTR=n && \
+	depends on KERNFS=n && EXT2_FS_XATTR=n && EXT3_FS_XATTR=n && TMPFS_XATTR=n && \
 AUFS_XATTR=n && CIFS_XATTR=n && F2FS_FS_XATTR=n && JFFS2_FS_XATTR=n && \
 REISERFS_FS_XATTR=n && SQUASHFS_XATTR=n && YAFFS_XATTR=n
 
@@ -295,6 +295,27 @@ REISERFS_FS_XATTR=n && SQUASHFS_XATTR=n && YAFFS_XATTR=n
 	  Users considering disabling this option should consider the specific
 	  filesystems. Some filesystems (e.g. EXT2/EXT3/TMPFS) need the support
 	  for XATTR.
+
+	  If unsure, say N here.
+
+config BAD_INODE_NO_SUPPORT
+	bool "Disable bad_inode support"
+	default n
+	depends on FUSE_FS=n && UBIFS_FS=n && JFFS2_FS=n && EXT2_FS=n && UDF_FS=n && \
+UFS_FS=n && BTRFS_FS=n && ECRYPT_FS=n && EXT4_FS=n && HFS_FS=n && NILFS2_FS=n && \
+OCFS2_FS=n && OMFS_FS=n && REISERFS_FS=n && F2FS_FS=n
+
+	help
+	  This option disable the support for bad_inode.
+
+	  Sometimes the embedded system is just running in the single process,
+	  do one thing or simple thing. It will not need the specific filesystem
+	  (e.g. EXT2/JFFS2). And then it will not need the bad_inode support.
+
+	  So users can say Y here to decrease the size of kernel.
+
+	  While users considering disabling this option should consider the specific
+	  filesystems. Some filesystems (e.g. EXT2/JFFS2) need the support for bad_inode.
 
 	  If unsure, say N here.
 

--- a/fs/bad_inode.c
+++ b/fs/bad_inode.c
@@ -8,6 +8,8 @@
  *  Fabian Frederick : August 2003 - All file operations assigned to EIO
  */
 
+#ifndef CONFIG_BAD_INODE_NO_SUPPORT
+
 #include <linux/fs.h>
 #include <linux/export.h>
 #include <linux/stat.h>
@@ -359,3 +361,6 @@ void iget_failed(struct inode *inode)
 	iput(inode);
 }
 EXPORT_SYMBOL(iget_failed);
+
+#endif /* !CONFIG_BAD_INODE_NO_SUPPORT */
+

--- a/fs/fs-writeback.c
+++ b/fs/fs-writeback.c
@@ -319,7 +319,18 @@ static int write_inode(struct inode *inode, struct writeback_control *wbc)
 {
 	int ret;
 
+/*
+ * In single process embedded system there is no specific filesystem like ext2/jffs2,
+ * so users can disable the support for bad_inode.
+ * In the case the function 'make_bad_inode' is never called to make an inode bad,
+ * so there is no bad inode, and then it don't need to decide if the inode is
+ * a bad inode.
+ */
+#ifndef CONFIG_BAD_INODE_NO_SUPPORT
 	if (inode->i_sb->s_op->write_inode && !is_bad_inode(inode)) {
+#else
+	if (inode->i_sb->s_op->write_inode) {
+#endif
 		trace_writeback_write_inode_start(inode, wbc);
 		ret = inode->i_sb->s_op->write_inode(inode, wbc);
 		trace_writeback_write_inode(inode, wbc);

--- a/fs/xattr.c
+++ b/fs/xattr.c
@@ -7,6 +7,9 @@
   Copyright (C) 2001 SGI - Silicon Graphics, Inc <linux-xfs@oss.sgi.com>
   Copyright (c) 2004 Red Hat, Inc., James Morris <jmorris@redhat.com>
  */
+
+#ifndef CONFIG_XATTR_NO_SUPPORT
+
 #include <linux/fs.h>
 #include <linux/slab.h>
 #include <linux/file.h>
@@ -971,3 +974,6 @@ void simple_xattr_list_add(struct simple_xattrs *xattrs,
 	list_add(&new_xattr->list, &xattrs->head);
 	spin_unlock(&xattrs->lock);
 }
+
+#endif	/* !CONFIG_XATTR_NO_SUPPORT */
+


### PR DESCRIPTION
Add a kernel config option - CONFIG_XATTR_NO_SUPPORT.
This option disables the support for XATTR (Extended Attributes).

Sometimes the embedded system is just running in the single process,
do one thing or simple thing. It will not need the specific
filesystem (e.g. EXT2/EXT3/TMPFS). And then It will not need the
XATTR support.

So disable the support for XATTR to decrease the size of kernel.
Then some XATTR family syscall definitions will not be compiled.

Users considering disabling this option should consider the specific
filesystems. Some filesystems (e.g. EXT2/EXT3/TMPFS) need the support
for XATTR.

The bloat score for the config CONFIG_XATTR_NO_SUPPORT is:

add/remove: 0/41 grow/shrink: 0/1 up/down: 0/-3479 (-3479)
function                                     old     new   delta
xattr_getsecurity                              6       -      -6
simple_xattr_list_add                         13       -     -13
simple_xattr_remove                           14       -     -14
fdget                                         42      28     -14
sys_lremovexattr                              16       -     -16
sys_removexattr                               19       -     -19
sys_llistxattr                                21       -     -21
sys_listxattr                                 21       -     -21
vfs_listxattr                                 22       -     -22
simple_xattr_set                              23       -     -23
sys_lgetxattr                                 26       -     -26
sys_getxattr                                  26       -     -26
sys_setxattr                                  31       -     -31
sys_lsetxattr                                 31       -     -31
removexattr                                   56       -     -56
generic_removexattr                           57       -     -57
simple_xattr_alloc                            59       -     -59
xattr_resolve_name                            63       -     -63
generic_getxattr                              68       -     -68
sys_flistxattr                                73       -     -73
simple_xattr_get                              75       -     -75
vfs_getxattr                                  79       -     -79
sys_fremovexattr                              79       -     -79
__vfs_setxattr_noperm                         79       -     -79
vfs_xattr_cmp                                 85       -     -85
simple_xattr_list                             86       -     -86
path_listxattr                                86       -     -86
sys_fgetxattr                                 88       -     -88
generic_setxattr                              90       -     -90
path_getxattr                                 93       -     -93
path_removexattr                             103       -    -103
vfs_setxattr                                 107       -    -107
vfs_removexattr                              113       -    -113
sys_fsetxattr                                118       -    -118
path_setxattr                                119       -    -119
generic_listxattr                            138       -    -138
vfs_getxattr_alloc                           162       -    -162
listxattr                                    168       -    -168
xattr_permission                             205       -    -205
__simple_xattr_set                           221       -    -221
getxattr                                     262       -    -262
setxattr                                     264       -    -264

Signed-off-by: David Dong zhiweix.dong@intel.com
